### PR TITLE
Fix author link on homepage

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -267,3 +267,10 @@ form {
   margin-top: 10px;
   margin-bottom: 10px;
 }
+
+.remove-btn {
+  background: none;
+  border: none;
+  text-decoration: underline;
+  color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1));
+}

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -1,12 +1,42 @@
-<div class="d-inline-block">
-  <%= link_to "Update author", edit_author_path(@author), class: 'btn btn-primary' %>
-</div>
-<div class="d-inline-block">
-  <%= button_to "Remove author", @genre, method: :delete, class: 'btn btn-danger' %>
+<div class="row">
+  <div class="col-md-12 text-center">
+    <div class="d-inline-block">
+      <%= link_to 'Update author', edit_author_path(@author), class: 'btn btn-primary' %>
+    </div>
+    <div class="d-inline-block">
+      <%= button_to 'Remove author', @genre, method: :delete, class: 'btn btn-danger' %>
+    </div>
+    <hr>
+    <h1><%= @author.full_name %></h1>
+    <h3><%= @author.nationality %></h3>
+  </div>
 </div>
 
 <div class="row">
-  <div class="col-md-2">
-    <%= render @author %>
+  <div class="col-md-12">
+    <h3>Books by this author: (<%= @author.books.count %>)</h3>
+    <div class="row">
+      <% @author.books.each do |book| %>
+        <div class="col">
+          <div class="card" style="width: 20rem;">
+            <div class="card-body">
+              <h5 class="card-title">
+                <%= book.title %>
+              </h5>
+              <p class="card-text">
+                <strong>Genre:</strong> <%= link_to book.genre.name, book.genre %><br>
+                <strong>Currently on shelf:</strong> <%= book.status %>
+              </p>
+              <div class="d-inline-block">
+                <%= link_to 'Edit', edit_book_path(book) %>
+              </div>
+              <div class="d-inline-block">
+                <%= button_to 'Remove', book, method: :delete, class: 'remove-btn' %>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -18,7 +18,7 @@
           <li>
             <%= link_to book.title, edit_book_path(book) %>
             by
-            <%= link_to book.author.full_name %>
+            <%= link_to book.author.full_name, author_path(book.author) %>
             <span class="badge text-<%= state_klass(book) %>"><%= book.current_state %></span>
             <span class="badge rounded-pill text-bg-<%= length_klass(book) %>"><%= book.length_in_words %></span>
             <% if book.rating.present? %>


### PR DESCRIPTION
When you click the author link on the home page, it would just refresh the page.

This PR updates the link to redirect to the author's page, which also now includes a list of books by that author (see screenshot below)

<img width="1344" alt="Screenshot 2024-06-08 at 11 56 55" src="https://github.com/rubyandcoffee/reading_list/assets/18640195/0b418880-b3c3-4c52-9770-8ed87ae3f2ef">