### PR TITLE
Change labels to checkboxes and only include unread books in generator

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -93,7 +93,7 @@ class BooksController < ApplicationController
   end
 
   def generator
-    book = BookGoal.where(year: DateTime.now.year).pluck(:book_id).sample
+    book = BookGoal.includes(book: :book_transitions).where(year: DateTime.now.year, book: { book_transitions: { to_state: 'unread', most_recent: true }}).pluck(:book_id).sample
     @book = Book.find(book)
   end
 

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -11,6 +11,10 @@ module BooksHelper
     end
   end
 
+  def checkbox_icon(book)
+    checkbox_klasses.fetch(book.current_state)
+  end
+
   def length_klass(book)
     if book.short?
       'light'
@@ -44,7 +48,19 @@ module BooksHelper
       'read' => 'bg-success',
       'tbr' => 'bg-warning',
       'reading' => 'bg-primary',
-      'unread' => 'bg-info'
+      'unread' => 'bg-info',
+      'dnf' => 'bg-primary'
+    }
+  end
+
+  def checkbox_klasses
+    {
+      'buy' => 'fa-regular fa-square',
+      'read' => 'fa-regular fa-square-check',
+      'dnf' => 'fa-solid fa-poo',
+      'tbr' => 'fa-regular fa-square',
+      'reading' => 'fa-regular fa-square',
+      'unread' => 'fa-regular fa-square'
     }
   end
 end

--- a/app/views/books/_book_details.html.erb
+++ b/app/views/books/_book_details.html.erb
@@ -1,11 +1,5 @@
 <div>
-  <% if book.current_state == 'read' %>
-    <i class="fa-regular fa-square-check"></i>
-  <% elsif book.current_state == 'dnf' %>
-    <i class="fa-solid fa-poo"></i>
-  <% else %>
-    <i class="fa-regular fa-square"></i>
-  <% end %>
+  <i class="<%= checkbox_icon(book) %>"></i>
   <%= link_to book.title, edit_book_path(book) %> by <%= book.author.full_name %>
   <span class="badge rounded-pill text-bg-<%= length_klass(book) %>"><%= book.length_in_words %></span>
   <span class="badge rounded-pill text-bg-<%= length_klass(book) %>"><%= time_to_read(book) %> hours</span>

--- a/app/views/series/index.html.erb
+++ b/app/views/series/index.html.erb
@@ -26,12 +26,15 @@
             <div class="accordion-body series-books">
               <% series.books.order(:series_position).each do |book| %>
                 <p>
-                  <strong><%= book.series_position %>.</strong>
+                  <i class="<%= checkbox_icon(book) %>"></i>
+                  <strong><%= book.series_position.ordinalize %></strong>
                   <%= link_to book.title, edit_book_path(book) %>
-                  <span class="badge rounded-pill <%= state_klass(book) %>">
-                    <%= book.current_state.humanize %>
-                    <span class="visually-hidden"><%= book.current_state.humanize %></span>
-                  </span>
+                  <% if book.status == 'Buy' %>
+                    <span class="badge rounded-pill bg-danger">
+                      <%= book.current_state.humanize %>
+                      <span class="visually-hidden"><%= book.current_state.humanize %></span>
+                    </span>
+                  <% end %>
                   <% if book.rating.present? %>
                     <% book.rating.times do |rate| %>
                       <i class="fa-solid fa-star"></i>


### PR DESCRIPTION
Closes #64 

Change labels to checkboxes.
Also only includes 'unread' books on the Generator page

<img width="508" alt="Screenshot 2024-06-08 at 16 17 20" src="https://github.com/rubyandcoffee/reading_list/assets/18640195/1034059a-bbaf-47a3-8dd5-1f3d3a74a99d">