### PR TITLE
Update book status if goal in current month

### DIFF
--- a/app/jobs/book_goals_status_job.rb
+++ b/app/jobs/book_goals_status_job.rb
@@ -1,0 +1,21 @@
+# To run this job: $ BookGoalsStatusJob.perform_now
+class BookGoalsStatusJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    current_year = DateTime.current.year.to_s
+    current_month = Date::MONTHNAMES[DateTime.current.month]
+    BookGoal.where(month: current_month, year: current_year).each do |goal|
+      book = goal.book
+      unless matches_state?(book, 'reading') || matches_state?(book, 'read')
+        goal.book.transition_to(:tbr)
+      end
+    end
+  end
+
+  private
+
+  def matches_state?(book, status)
+    book.current_state == status
+  end
+end

--- a/app/jobs/book_goals_status_job.rb
+++ b/app/jobs/book_goals_status_job.rb
@@ -7,15 +7,9 @@ class BookGoalsStatusJob < ApplicationJob
     current_month = Date::MONTHNAMES[DateTime.current.month]
     BookGoal.where(month: current_month, year: current_year).each do |goal|
       book = goal.book
-      unless matches_state?(book, 'reading') || matches_state?(book, 'read')
-        goal.book.transition_to(:tbr)
+      if book.current_state == 'unread'
+        book.transition_to(:tbr)
       end
     end
-  end
-
-  private
-
-  def matches_state?(book, status)
-    book.current_state == status
   end
 end


### PR DESCRIPTION
Solves #78 

Within Yearly Goals, for every `Book` that has a `BookGoal` of the current month, and has a `status` of 'unread', update these to have a `status` of 'tbr'.