### PR TITLE
Limit nationality drodown

### DIFF
--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -10,10 +10,6 @@ class Author < ApplicationRecord
     ["books"]
   end
 
-  def self.nationalities
-    Nationality::Nationality.default_option("british")
-  end
-
   def full_name
     forename + ' ' + surname
   end

--- a/app/views/authors/_form.html.erb
+++ b/app/views/authors/_form.html.erb
@@ -28,7 +28,7 @@
 
   <div>
     <%= form.label :nationality, style: 'display: block' %>
-    <%= form.select :nationality, options_for_select(Author.nationalities, selected: form.object.nationality), { include_blank: true }, { class: 'form-select' } %>
+    <%= form.select :nationality, options_for_select(Nationality::Nationality.default_option('british'), selected: form.object.nationality), { include_blank: true }, { class: 'form-select' } %>
   </div>
 
   <%= form.hidden_field :book, value: @book %>

--- a/app/views/shared/search/_authors.html.erb
+++ b/app/views/shared/search/_authors.html.erb
@@ -6,7 +6,7 @@
     </div>
     <div class="col-12">
       <%= f.label :nationality_eq, 'Nationality' %>
-      <%= f.select :nationality_eq, Author.nationalities, { include_blank: true }, class: 'form-select' %>
+      <%= f.select :nationality_eq, Author.pluck(:nationality).uniq, { include_blank: true }, class: 'form-select' %>
     </div>
     <div class="col-12">
       <%= f.label :gender_eq, 'Gender' %>

--- a/app/views/shared/search/_books.html.erb
+++ b/app/views/shared/search/_books.html.erb
@@ -10,7 +10,7 @@
     </div>
     <div class="col-12">
       <%= f.label :author_nationality_eq, 'Nationality' %>
-      <%= f.select :author_nationality_eq, Author.nationalities, { include_blank: true }, class: 'form-select' %>
+      <%= f.select :author_nationality_eq, Author.pluck(:nationality).uniq, { include_blank: true }, class: 'form-select' %>
     </div>
     <div class="col-12">
       <%= f.label :author_gender_eq, 'Gender' %>


### PR DESCRIPTION
When searching for a book on the home page, or searching for an author on the Authors page, you can filter by nationality.
However, the nationality dropdown lists ALL nationalities, instead of just the nationalities that I actually have.

e.g. If I have 3 authors of 3 different nationalities, then the dropdown should only list 3 nationalities.