### PR TITLE
Filter shopping list by new 'buy' field on Books

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -67,7 +67,7 @@ class BooksController < ApplicationController
   end
 
   def buy
-    @books = Book.where(purchased: false)
+    @books = Book.where(buy: true)
   end
 
   def todo
@@ -87,7 +87,7 @@ class BooksController < ApplicationController
   end
 
   def export
-    @books = Book.where(purchased: false).sort_by { |b| b.author.surname }
+    @books = Book.where(buy: true).sort_by { |b| b.author.surname }
 
     respond_to do |format|
       format.html
@@ -132,6 +132,6 @@ class BooksController < ApplicationController
     end
 
     def book_params
-      params.require(:book).permit(:title, :total_pages, :author_id, :status, :rating, :series_id, :series_position, :purchased, genre_ids: [], book_goals_attributes: [:id, :month, :year, :_destroy], rental_attributes: [:id, :loaner_id, :active])
+      params.require(:book).permit(:title, :total_pages, :author_id, :status, :rating, :series_id, :series_position, :purchased, :buy, genre_ids: [], book_goals_attributes: [:id, :month, :year, :_destroy], rental_attributes: [:id, :loaner_id, :active])
     end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -73,5 +73,6 @@ class Book < ApplicationRecord
     Book
       .joins(:book_goals)
       .where(book_goals: { month: Time.now.strftime("%B"), year: Time.now.year} )
+      .and(where(status: 'unread'))
   end
 end

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -56,8 +56,18 @@
     <hr>
     <div class="form-field">
       <%= form.check_box :purchased, { style: 'margin-right: 5px;' } %>
-      <%= form.label :purchased, 'Purchased' %>
+      <%= form.label :purchased do %>
+        <i class="fa-solid fa-sack-dollar"></i>
+        Purchased
+      <% end %>
       <span class="small-text">Remember to uncheck this if you don't own it yet</span>
+    </div>
+    <div class="form-field">
+      <%= form.check_box :buy, { style: 'margin-right: 5px;' } %>
+      <%= form.label :buy do %>
+        <i class="fa-solid fa-cart-shopping"></i>
+        Add to shopping list?
+      <% end %>
     </div>
     <div class="form-field">
       <%= form.fields_for :rental do |rental| %>

--- a/app/views/books/generator.html.erb
+++ b/app/views/books/generator.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-12 text-center book-generator">
     <i class="fa-solid fa-wand-magic-sparkles"></i>
-    <h3>Your next book to read is <strong><%= @book.title %></strong> by <%= @book.author.full_name %></h3>
+    <h3>Your next book to read is <strong><%= link_to @book.title, edit_book_path(@book) %></strong> by <%= @book.author.full_name %></h3>
   </div>
 </div>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -22,7 +22,7 @@
             by
             <%= link_to book.author.full_name, author_path(book.author) %>
             <span class="badge text-<%= state_klass(book) %>"><%= book.status %></span>
-            <% unless book.purchased %>
+            <% if book.buy %>
               <span class="badge text-bg-danger">Buy</span>
             <%  end %>
             <span class="badge rounded-pill text-bg-<%= length_klass(book) %>"><%= book.length_in_words %></span>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -8,7 +8,7 @@
         </h5>
         <p class="card-text">
           <strong>Genres:</strong>
-          <% book.genres.each do |genre| %>
+          <% @book.genres.each do |genre| %>
             <%= link_to genre.name, genre %><br>
           <% end %>
           <strong>Currently on shelf:</strong> <%= @book.status %>

--- a/app/views/books/yearly_goals.html.erb
+++ b/app/views/books/yearly_goals.html.erb
@@ -28,6 +28,18 @@
   </div>
   <div class="row">
     <div class="col-md-12">
+      <hr>
+      <h3>The Rules</h3>
+      <ol>
+        <li>You cannot buy a physical book without reading 3 physical books you already own</li>
+        <li>Each month, you must read at least 2 physical books you already own</li>
+        <li>If you DNF a physical book, you must donate it to a charity shop</li>
+      </ol>
+      <hr>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
       <% Date::MONTHNAMES.each do |month| %>
         <div class="monthly-books">
           <% if @book_goals.where(month: month).any? %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_08_095706) do
+ActiveRecord::Schema[7.0].define(version: 2025_05_04_193528) do
   create_table "authors", force: :cascade do |t|
     t.string "forename"
     t.string "surname"
@@ -41,6 +41,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_08_095706) do
     t.boolean "purchased", default: true
     t.datetime "deleted_at"
     t.string "status", default: "unread"
+    t.boolean "buy", default: false, null: false
     t.index ["author_id"], name: "index_books_on_author_id"
     t.index ["deleted_at"], name: "index_books_on_deleted_at"
     t.index ["series_id"], name: "index_books_on_series_id"


### PR DESCRIPTION
Previously, the shopping list was filtered by the 'purchased' column on Books. 
If a book wasn't purchased, it was incorrectly assumed that the Book should go on the Shopping List.

Now, a book will only be on the Shopping List if the user has opted to add it to the Shopping List via the 'buy' attribute.

- Also fixed a bug where Book#show page wouldn't load due to incorrect variable
- TBR now only includes books that are unread
- Added Rules to Book Goals
- Added link to Generator