### PR TITLE
Add dashboard metrics for total, unread, and read books

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -293,6 +293,7 @@ form {
 }
 
 #yearly-goals-header {
+  margin-top: 20px;
   margin-bottom: 50px;
 }
 

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -114,7 +114,11 @@ class BooksController < ApplicationController
 
   def yearly_goals
     @book_goals = BookGoal.this_year
-    @books = Book.joins(:book_goals).where(book_goals: { year: DateTime.now.year }).order(:title).paginate(page: params[:page], per_page: 20)
+    @books = Book
+               .joins(:book_goals)
+               .where(book_goals: { year: DateTime.now.year })
+               .order(:title)
+               .paginate(page: params[:page], per_page: 20)
   end
 
   def generator

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
   def currently_reading
-    Book.where(status: 'reading').last
+    Book.where(status: 'reading')
   end
 end

--- a/app/views/books/_book_goal_fields.erb
+++ b/app/views/books/_book_goal_fields.erb
@@ -18,6 +18,5 @@
         <i class="fa-solid fa-xmark"></i>
       <% end %>
     </div>
-    <%= f.hidden_field :year, value: DateTime.now.year %>
   <% end %>
 </div>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -12,8 +12,31 @@
         <%= will_paginate @books, renderer: WillPaginate::ActionView::BootstrapLinkRenderer %>
       </div>
     </div>
-    <div id="app"><hello-world></hello-world></div>
-
+    <div class="row">
+      <div class="col-md-3">
+        <div class="card" style="width: 12rem; height: 6rem;">
+          <div class="card-body" style="text-align: center;">
+            <h5 class="card-title">You have <%= Book.all.count %> books</h5>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="card" style="width: 12rem; height: 6rem;">
+          <div class="card-body" style="text-align: center;">
+            <h5 class="card-title"><%= Book.unread.count %> books are unread</h5>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="card" style="width: 12rem; height: 6rem;">
+          <div class="card-body" style="text-align: center;">
+            <h5 class="card-title">So you've only read <%= ((Book.read.count.to_f / Book.count.to_f) * 100).round(0) %>%</h5>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Vue code below does work (as proof that VueJS is setup correctly), just commenting it out for now -->
+    <!-- <div id="app"><hello-world></hello-world></div>-->
     <% if @books.any? %>
       <ul>
         <% @books.each do |book| %>

--- a/app/views/books/yearly_goals.html.erb
+++ b/app/views/books/yearly_goals.html.erb
@@ -56,8 +56,8 @@
         <div class="monthly-books">
           <% if @book_goals.where(month: month).any? %>
             <h3><%= month.nil? ? 'Undecided' : month %> (<%= @book_goals.where(month: month).map{ |goal| time_to_read(goal.book) }.compact.sum %> hours total)</h3>
-            <% @book_goals.includes(:book).where(month: month).each do |book_goal| %>
-              <%= render partial: 'book_details', locals: { book: Book.find(book_goal.book_id) } %>
+            <% @book_goals.includes(:book).joins(:book).where(month: month).order('books.status').each do |book_goal| %>
+              <%= render partial: 'book_details', locals: { book: book_goal.book } %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/books/yearly_goals.html.erb
+++ b/app/views/books/yearly_goals.html.erb
@@ -4,21 +4,33 @@
   </div>
 </div>
 <% if @books.any? %>
-  <div class="row" id="yearly-goals-header">
-    <div class="col-md-6">
-      <h5>You are reading <%= pluralize(@books.count, 'book') %> this year</h5>
-      <p>
-        This includes <%= @books.filter_by_length('Short').count %> short books,
-        <%= @books.filter_by_length('Medium').count %> medium books and
-        <%= @books.filter_by_length('Long').count %> long books.
-      </p>
-      <p>
-        You have already read <%= @books.where(status: 'read').count %> books this year (not including dnf),<br>
-        <%= @books.count - @books.where(status: 'read').count %> left to go.
-      </p>
+  <div class="row">
+    <div class="col-md-3">
+      <div class="card" style="width: 12rem; height: 14rem;">
+        <div class="card-body" style="text-align: center;">
+          <h5 class="card-title">
+            Reading<br>
+            <span style="font-size: 4rem;"><%= @books.count %></span><br>
+            this year
+          </h5>
+        </div>
+      </div>
     </div>
-    <div class="col-md-6">
-      <p>The recommendation is that for each month, you read each of the following:</p>
+    <div class="col-md-3">
+      <div class="card" style="width: 14rem; height: 14rem;">
+        <div class="card-body" style="text-align: center;">
+          <h5 class="card-title">
+            Read so far<br>
+            <span style="font-size: 4rem;"><%= @books.where(status: 'read').count %></span>
+          </h5>
+          <p class="card-text">
+            (<%= @books.count - @books.where(status: 'read').count %> left to go)
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-6" id="yearly-goals-header">
+      <h3>Recommendations each month:</h3>
       <ul>
         <li>A book by Philippa Gregory (long)</li>
         <li>A book that's been on the bookshelf for years (medium)</li>

--- a/app/views/series/index.html.erb
+++ b/app/views/series/index.html.erb
@@ -32,8 +32,8 @@
                   <%= link_to book.title, edit_book_path(book) %>
                   <% unless book.purchased? %>
                     <span class="badge rounded-pill bg-danger">
-                      <%= book.status %>
-                      <span class="visually-hidden"><%= book.status %></span>
+                      Buy
+                      <span class="visually-hidden">Buy</span>
                     </span>
                   <% end %>
                   <% if book.rating.present? %>

--- a/app/views/shared/_right_sidebar.html.erb
+++ b/app/views/shared/_right_sidebar.html.erb
@@ -1,16 +1,19 @@
 <div id="right-sidebar">
-  <% if currently_reading.present? %>
+  <% if currently_reading.any? %>
     <div class="toast show" role="alert" aria-live="assertive" aria-atomic="true">
       <div class="toast-header">
         <strong class="me-auto">Currently reading</strong>
         <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
       </div>
       <div class="toast-body">
-        <%= currently_reading.title %>
-        by <%= currently_reading.author.full_name %>
-        <span class="small-text">
-          <%= link_to 'Update Status', edit_book_path(currently_reading) %>
-        </span>
+        <% currently_reading.each do |reading| %>
+          <%= reading.title %>
+          by <%= reading.author.full_name %>
+          <span class="small-text">
+            <%= link_to 'Update Status', edit_book_path(reading) %>
+          </span>
+          <hr>
+        <% end %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
Added metrics to Dashboard page and Yearly Goals page (screenshots below).

Also:
- Fix bug where year was updated with every BookGoal save
- Add ability to have multiple books in Currently Reading sidebar
- Order book goals by completion status
- The badge next to each book on the 'Series' page now only shows 'Buy' if purchased (instead of other statuses)

---

### Dashboard 
See metrics in screenshot below
<img width="850" alt="Screenshot 2025-05-04 at 21 16 27" src="https://github.com/user-attachments/assets/9e5c6753-16ef-40c9-8f11-a1a5f5ab3f05" />

<hr>

### Yearly Goals 
See metrics in screenshot below
<img width="1037" alt="Screenshot 2025-05-04 at 21 30 55" src="https://github.com/user-attachments/assets/b3910865-cce0-4be5-806d-827897571685" />
